### PR TITLE
Change behavior of exporting table files without -x flag

### DIFF
--- a/bqup/routine.py
+++ b/bqup/routine.py
@@ -120,14 +120,7 @@ class Routine:
         routine_file_name = '{}.{}.{}'.format(self.routine_id, 'function' if self.is_function else 'procedure', self._get_export_file_extension())
         return path.join(dataset_dir, routine_file_name)
 
-    def to_file_contents(self):
-        """Return file contents
-
-        Returns
-        -------
-        str
-            File contents
-        """
+    def to_file_contents(self) -> str:
         return self.routine_query
 
     def print_info(self):

--- a/bqup/table.py
+++ b/bqup/table.py
@@ -72,14 +72,7 @@ class Table:
         table_file_name = '{}.{}.{}'.format(self.table_id, self.table_type.lower(), self._get_export_file_extension())
         return path.join(dataset_dir, table_file_name)
 
-    def to_file_contents(self):
-        """Return file contents
-
-        Returns
-        -------
-        str
-            File contents
-        """
+    def to_file_contents(self) -> str:
         return self.view_query or json.dumps(self.schema)
 
     def print_info(self):

--- a/bqup/table.py
+++ b/bqup/table.py
@@ -29,8 +29,8 @@ class Table:
     def __init__(self, dataset, export_schema, bq_table):
         self.dataset = dataset
         self.table_id = bq_table.table_id
-        print('\t\tLoading table/view {}...'.format(self.table_id))
         self.table_type = bq_table.table_type
+        print(f'\t\tLoading {self.table_type} {self.table_id}...')
         self.export_schema = export_schema
         dataset.tables.append(self)
 
@@ -89,8 +89,7 @@ class Table:
     def print_info(self):
         """Print information about the table
         """
-        print('\t\t[{}] {} ({} bytes)'.format(
-            self.table_type, self.table_id, len(self.view_query)))
+        print(f'\t\t[{self.table_type}] {self.table_id} ({len(self.view_query)} bytes)')
 
     def export(self, dataset_dir):
         """Export dataset to specified directory as either an "sql" or "json" file
@@ -100,7 +99,6 @@ class Table:
         dataset_dir : str
             Directory where dataset will be saved
         """
-        if self.table_type == 'VIEW' or self.export_schema:
-            table_path = self._get_export_table_path(dataset_dir)
-            with open(table_path, 'w', encoding='utf-8') as f:
-                f.write(self.to_file_contents())
+        table_path = self._get_export_table_path(dataset_dir)
+        with open(table_path, 'w', encoding='utf-8') as f:
+            f.write(self.to_file_contents())


### PR DESCRIPTION
Previously, running without `-x` would not create `*.table.json` files. Now, the same will create empty `*.table.json` files. Rationale is as follows:
- Table IDs in the form of `project.dataset.table` are all we need to create these files. These are already fetched with every dataset and there's no additional cost to creating empty files for these
- Previously, getting a list of tables in the project was coupled with exporting the schemata for each table. Fetching the schema for each table is a network operation that takes a lot of time. This was prohibitive for the use case where we only want the list of tables but not their schemata.