### PR TITLE
Handle routines with no args & README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ python3 setup.py install
 You can list down the options by running `bqup --help`.
 
 ```text
-bqup [-p PROJECT_ID] [-d TARGET_DIR] [-fvx]
+bqup [-p PROJECT_ID] [-d TARGET_DIR] [-fvxr] [-e REGEX]
 
 Options:
   -p PROJECT_ID, --project PROJECT_ID  Project ID to load. If unspecified,
@@ -46,6 +46,8 @@ Options:
   -f --force                           Overwrite target directory if it exists.
   -v --verbose                         Print a summary of the loaded project.
   -x --schema                          Export table schemata as json.
+  -r --routine                         Include routines in export.
+  -e REGEX, --regex REGEX              Regex pattern to filter datasets to be exported.
 ```
 
 ### Development

--- a/bqup/routine.py
+++ b/bqup/routine.py
@@ -31,7 +31,7 @@ class Routine:
 
     def _get_arguments(self, routine):
         arguments_str = ''
-        arguments = routine.to_api_repr()['arguments']
+        arguments = routine.to_api_repr().get('arguments',[])
         if len(arguments) > 0:
             arguments_str = ', '.join((self._get_parameter(argument) for argument in arguments))
         return arguments_str


### PR DESCRIPTION
A simple fix for routines with zero arguments. 
Also updated README to expose -r and -e options. 